### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fetch-release.yaml
+++ b/.github/workflows/fetch-release.yaml
@@ -1,4 +1,6 @@
 name: Fetch GitHub Releases
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/OWASP/www-project-nightingale/security/code-scanning/1](https://github.com/OWASP/www-project-nightingale/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow fetches GitHub releases and commits changes to the repository, it requires `contents: write` permission. Adding this block at the root level ensures that all jobs in the workflow inherit these permissions unless overridden.

The `permissions` block should be added immediately after the `name` field in the workflow file. No additional dependencies or imports are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
